### PR TITLE
EVDOC01-167: L'opció d'Obtindre un enllaç de l'eina Videoconferència no el copia al portapapers

### DIFF
--- a/meetings/ui/src/main/frontend/src/components/sakai-meeting-card.vue
+++ b/meetings/ui/src/main/frontend/src/components/sakai-meeting-card.vue
@@ -640,16 +640,15 @@ export default {
       this.$router.push({name: "EditMeeting", params: { id: this.id}});
     },
     getMeetingLink() {
-      const storage = document.createElement('textarea');
-      storage.value = this.url;
-      this.$el.appendChild(storage);
-      storage.select();
-      storage.setSelectionRange(0, 99999);
-      document.execCommand('copy');
-      this.$el.removeChild(storage);
-      this.showBannerInfo = true;
-      setTimeout(function(){ this.showBannerInfo = false; }.bind(this), 3000);
-      return false;
+      navigator.clipboard.writeText(this.url).then(() => {
+        this.showBannerInfo = true;
+        setTimeout(() => {
+          this.showBannerInfo = false;
+        }, 3000);
+      }).catch(err => {
+        console.error('Error copying to clipboard: ', err);
+      });
+        return false;
     },
     checkMeetingRecordings() {
       let parameters = {


### PR DESCRIPTION
Abans en clicar sobre l'opció "Obtindré enllaç" no es copiaba l'enllaç al portapapers i eixia un error: DOMException: Node.appendChild: Cannot add children to a Text. Ara ja funciona correctament, perquè es copia l'enllaç i no ix el error.

![image](https://github.com/user-attachments/assets/3be147d3-6e3b-4087-9736-a707dd343167)

